### PR TITLE
adds price sample

### DIFF
--- a/json/price.json
+++ b/json/price.json
@@ -1,0 +1,8 @@
+{
+  "price": {
+    "product_id": "SPREE-T-SHIRT",
+    "price": 12.95,
+    "list_price": 13.50,
+    "cost_price": 6.25
+  }
+}

--- a/lib/hub/samples.rb
+++ b/lib/hub/samples.rb
@@ -4,7 +4,7 @@ require 'json'
 module Hub
   module Samples
     def self.available
-        %w[cart inventory order product shipment]
+        %w[cart inventory order price product shipment]
     end
   end
 end
@@ -14,6 +14,7 @@ require 'hub/samples/cart'
 require 'hub/samples/inventory'
 require 'hub/samples/order'
 require 'hub/samples/product'
+require 'hub/samples/price'
 require 'hub/samples/shipment'
 require 'hub/samples/store'
 require 'hub/samples/customer'

--- a/lib/hub/samples/price.rb
+++ b/lib/hub/samples/price.rb
@@ -1,0 +1,26 @@
+module Hub::Samples
+  class Price < Base
+    class << self
+      def object
+        parsed_json('price')
+      end
+
+      def request
+        {
+          'request_id' => request_id,
+          'price' => object['price']
+        }
+      end
+
+      def message
+        {
+          'message' => 'price:new',
+          'store_id' => "51f788cf65762d3177000001",
+          'payload' => {
+            'price' => object['price']
+          }
+        }
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hello, I'm making a set_price endpoint for wombat, and adding a price sample to this repo was necessary to keep the pattern used in the spree_wombat specs for handlers.

Please consider adding this.

the spree_wombat PR is linked below:
https://github.com/spree/spree_wombat/pull/72

Thank you.